### PR TITLE
Updating test timings based on preliminary results

### DIFF
--- a/osic_scenarios/cinder/list_volumes_with_restart_keystone_service_on_one_node.yaml
+++ b/osic_scenarios/cinder/list_volumes_with_restart_keystone_service_on_one_node.yaml
@@ -5,7 +5,7 @@
     -
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:

--- a/osic_scenarios/glance/list_image_with_kill_keystone_service_on_one_node.yaml
+++ b/osic_scenarios/glance/list_image_with_kill_keystone_service_on_one_node.yaml
@@ -5,7 +5,7 @@
     -
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 240
         concurrency: 4
       context:
         users:

--- a/osic_scenarios/glance/list_image_with_restart_keystone_service_on_one_node.yaml
+++ b/osic_scenarios/glance/list_image_with_restart_keystone_service_on_one_node.yaml
@@ -5,7 +5,7 @@
     -
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 240
         concurrency: 4
       context:
         users:

--- a/osic_scenarios/keystone/authenticate_with_kill_memcached_service_on_one_node.yaml
+++ b/osic_scenarios/keystone/authenticate_with_kill_memcached_service_on_one_node.yaml
@@ -1,11 +1,11 @@
 ---
-{% set repeat = repeat|default(5) %}
+{% set repeat = repeat|default(3) %}
   Authenticate.keystone:
 {% for iteration in range(repeat) %}
     -
       runner:
         type: "constant_for_duration"
-        duration: 60
+        duration: 240
         concurrency: 5
       context:
         users:
@@ -20,5 +20,5 @@
             name: event
             args:
               unit: time
-              at: [15]
+              at: [60]
 {% endfor %}

--- a/osic_scenarios/keystone/authenticate_with_restart_memcached_service_on_one_node.yaml
+++ b/osic_scenarios/keystone/authenticate_with_restart_memcached_service_on_one_node.yaml
@@ -1,11 +1,11 @@
 ---
-{% set repeat = repeat|default(5) %}
+{% set repeat = repeat|default(3) %}
   Authenticate.keystone:
 {% for iteration in range(repeat) %}
     -
       runner:
         type: "constant_for_duration"
-        duration: 60
+        duration: 240
         concurrency: 5
       context:
         users:
@@ -20,5 +20,5 @@
             name: event
             args:
               unit: time
-              at: [15]
+              at: [60]
 {% endfor %}

--- a/osic_scenarios/neutron/create_and_list_networks_with_kill_mysql_service_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_kill_mysql_service_on_one_node.yaml
@@ -7,7 +7,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -25,5 +25,5 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]
 {% endfor %}

--- a/osic_scenarios/neutron/create_and_list_networks_with_kill_neutron_dhcp_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_kill_neutron_dhcp_agent_on_one_node.yaml
@@ -5,7 +5,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -23,4 +23,4 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]

--- a/osic_scenarios/neutron/create_and_list_networks_with_kill_neutron_l3_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_kill_neutron_l3_agent_on_one_node.yaml
@@ -5,7 +5,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -23,4 +23,4 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]

--- a/osic_scenarios/neutron/create_and_list_networks_with_kill_neutron_linuxbridge_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_kill_neutron_linuxbridge_agent_on_one_node.yaml
@@ -5,7 +5,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -23,4 +23,4 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]

--- a/osic_scenarios/neutron/create_and_list_networks_with_kill_neutron_metadata_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_kill_neutron_metadata_agent_on_one_node.yaml
@@ -5,7 +5,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -23,4 +23,4 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]

--- a/osic_scenarios/neutron/create_and_list_networks_with_kill_neutron_metering_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_kill_neutron_metering_agent_on_one_node.yaml
@@ -5,7 +5,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -23,4 +23,4 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]

--- a/osic_scenarios/neutron/create_and_list_networks_with_kill_neutron_server_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_kill_neutron_server_on_one_node.yaml
@@ -5,7 +5,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -23,4 +23,4 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]

--- a/osic_scenarios/neutron/create_and_list_networks_with_restart_mysql_service_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_restart_mysql_service_on_one_node.yaml
@@ -7,7 +7,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -25,5 +25,5 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]
 {% endfor %}

--- a/osic_scenarios/neutron/create_and_list_networks_with_restart_neutron_dhcp_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_restart_neutron_dhcp_agent_on_one_node.yaml
@@ -5,7 +5,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -23,4 +23,4 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]

--- a/osic_scenarios/neutron/create_and_list_networks_with_restart_neutron_l3_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_restart_neutron_l3_agent_on_one_node.yaml
@@ -5,7 +5,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -23,4 +23,4 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]

--- a/osic_scenarios/neutron/create_and_list_networks_with_restart_neutron_linuxbridge_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_restart_neutron_linuxbridge_agent_on_one_node.yaml
@@ -5,7 +5,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -23,4 +23,4 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]

--- a/osic_scenarios/neutron/create_and_list_networks_with_restart_neutron_metadata_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_restart_neutron_metadata_agent_on_one_node.yaml
@@ -5,7 +5,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -23,4 +23,4 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]

--- a/osic_scenarios/neutron/create_and_list_networks_with_restart_neutron_metering_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_restart_neutron_metering_agent_on_one_node.yaml
@@ -5,7 +5,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -23,4 +23,4 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]

--- a/osic_scenarios/neutron/create_and_list_networks_with_restart_neutron_server_on_one_node.yaml
+++ b/osic_scenarios/neutron/create_and_list_networks_with_restart_neutron_server_on_one_node.yaml
@@ -5,7 +5,7 @@
         network_create_args: {}
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -23,4 +23,4 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]

--- a/osic_scenarios/nova/boot_and_delete_with_reboot_one_node_with_rabbitmq_service.yaml
+++ b/osic_scenarios/nova/boot_and_delete_with_reboot_one_node_with_rabbitmq_service.yaml
@@ -9,7 +9,7 @@
         force_delete: false
       runner:
         type: "constant_for_duration"
-        duration: 120
+        duration: 480
         concurrency: 4
       context:
         users:
@@ -24,4 +24,4 @@
             name: event
             args:
               unit: time
-              at: [30]
+              at: [120]


### PR DESCRIPTION
Updated timings because some of the tests did not appear to have returned to baseline before the test completed.