### PR TITLE
Added new Neutron test scenarios

### DIFF
--- a/osic_scenarios/neutron/create-and-delete-networks_with_kill_mysql_service_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_kill_mysql_service_on_one_node.yaml
@@ -1,0 +1,29 @@
+---
+{% set repeat = repear|default(3) %}
+  NeutronNetworks.create_and_delete_networks:
+{% for iteration in range(repeat) %}
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 400
+        concurrency: 4
+      context:
+        users:
+          tenants: 3
+          users_per_tenant: 3
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: kill mysql service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]
+{% endfor %}

--- a/osic_scenarios/neutron/create-and-delete-networks_with_kill_neutron_dhcp_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_kill_neutron_dhcp_agent_on_one_node.yaml
@@ -1,0 +1,26 @@
+---
+  NeutronNetworks.create_and_delete_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 480
+        concurrency: 4
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: kill neutron-dhcp-agent service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]

--- a/osic_scenarios/neutron/create-and-delete-networks_with_kill_neutron_l3_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_kill_neutron_l3_agent_on_one_node.yaml
@@ -1,0 +1,26 @@
+---
+  NeutronNetworks.create_and_delete_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 480
+        concurrency: 4
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: kill neutron-l3-agent service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]

--- a/osic_scenarios/neutron/create-and-delete-networks_with_kill_neutron_linuxbridge_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_kill_neutron_linuxbridge_agent_on_one_node.yaml
@@ -1,0 +1,26 @@
+---
+  NeutronNetworks.create_and_delete_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 480
+        concurrency: 4
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: kill neutron-linuxbridge-agent service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]

--- a/osic_scenarios/neutron/create-and-delete-networks_with_kill_neutron_metadata_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_kill_neutron_metadata_agent_on_one_node.yaml
@@ -1,0 +1,26 @@
+---
+  NeutronNetworks.create_and_delete_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 480
+        concurrency: 4
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: kill neutron-metadata-agent service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]

--- a/osic_scenarios/neutron/create-and-delete-networks_with_kill_neutron_metering_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_kill_neutron_metering_agent_on_one_node.yaml
@@ -1,0 +1,26 @@
+---
+  NeutronNetworks.create_and_delete_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 480
+        concurrency: 4
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: kill neutron-metering-agent service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]

--- a/osic_scenarios/neutron/create-and-delete-networks_with_kill_neutron_server_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_kill_neutron_server_on_one_node.yaml
@@ -1,0 +1,26 @@
+---
+  NeutronNetworks.create_and_delete_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 480
+        concurrency: 4
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: kill neutron-server service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]

--- a/osic_scenarios/neutron/create-and-delete-networks_with_restart_mysql_service_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_restart_mysql_service_on_one_node.yaml
@@ -1,0 +1,29 @@
+---
+{% set repeat = repeat|default(3) %}
+  NeutronNetworks.create_and_delete_networks:
+{% for iteration in range(repeat) %}
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 480
+        concurrency: 4
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: restart mysql service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]
+{% endfor %}

--- a/osic_scenarios/neutron/create-and-delete-networks_with_restart_neutron_dhcp_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_restart_neutron_dhcp_agent_on_one_node.yaml
@@ -1,0 +1,26 @@
+---
+  NeutronNetworks.create_and_delete_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 480
+        concurrency: 4
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: restart neutron-dhcp-agent service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]

--- a/osic_scenarios/neutron/create-and-delete-networks_with_restart_neutron_l3_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_restart_neutron_l3_agent_on_one_node.yaml
@@ -1,0 +1,26 @@
+---
+  NeutronNetworks.create_and_delete_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 480
+        concurrency: 4
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: restart neutron-l3-agent service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]

--- a/osic_scenarios/neutron/create-and-delete-networks_with_restart_neutron_linuxbridge_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_restart_neutron_linuxbridge_agent_on_one_node.yaml
@@ -1,0 +1,26 @@
+---
+  NeutronNetworks.create_and_delete_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 480
+        concurrency: 4
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: restart neutron-linuxbridge-agent service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]

--- a/osic_scenarios/neutron/create-and-delete-networks_with_restart_neutron_metadata_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_restart_neutron_metadata_agent_on_one_node.yaml
@@ -1,0 +1,26 @@
+---
+  NeutronNetworks.create_and_delete_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 480
+        concurrency: 4
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: restart neutron-metadata-agent service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]

--- a/osic_scenarios/neutron/create-and-delete-networks_with_restart_neutron_metering_agent_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_restart_neutron_metering_agent_on_one_node.yaml
@@ -1,0 +1,26 @@
+---
+  NeutronNetworks.create_and_delete_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 480
+        concurrency: 4
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: restart neutron-metering-agent service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]

--- a/osic_scenarios/neutron/create-and-delete-networks_with_restart_neutron_server_on_one_node.yaml
+++ b/osic_scenarios/neutron/create-and-delete-networks_with_restart_neutron_server_on_one_node.yaml
@@ -1,0 +1,26 @@
+---
+  NeutronNetworks.create_and_delete_networks:
+    -
+      args:
+        network_create_args: {}
+      runner:
+        type: "constant_for_duration"
+        duration: 480
+        concurrency: 4
+      context:
+        users:
+          tenants: 1
+          users_per_tenant: 1
+        quotas:
+          neutron:
+            network: -1
+      hooks:
+        -
+          name: fault_injection
+          args:
+            action: restart neutron-server service on one node
+          trigger:
+            name: event
+            args:
+              unit: time
+              at: [120]


### PR DESCRIPTION
Due to the nature of the create_and_list_networks test
constantly incrementing the "list" operation as the networks
grow in number, we need to change the scenario to create and
rapidly delete the created networks so we can have a more
constant operation duration time